### PR TITLE
Update the react-native-modal to version 14.0.0-rc.1 to fix the error…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-youtube-popup-player",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A custom Youtube iframe player with a popup style and can exit the player by swiping down/up",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -81,7 +81,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-modal": "^13.0.1",
+    "react-native-modal": "^14.0.0-rc.1",
     "react-native-vector-icons": ">=9.2.0",
     "react-native-webview": "^13.13.2",
     "react-native-youtube-iframe-player": "*"


### PR DESCRIPTION
This pull request updates the react-native-modal to version '14.0.0-rc.1' to fix the error of _reactNative.BackHandler.removeEventListener.