### PR TITLE
Revert back to use react-native-youtube-iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-React Native Youtube Popup Player is a custom Youtube iframe player with a popup style and can exit the player by swiping down/up.
-
+# react-native-audio-player-button
 <span><img src="https://user-images.githubusercontent.com/18114944/218962104-0533269e-2ff3-49a5-9dd4-d7dd14e821e3.png" width="250" height="500" /></span>
+
+React Native Youtube Popup Player is a custom Youtube iframe player with a popup style and can exit the player by swiping down/up.
 
 ## Support
 iOS & Android
@@ -14,12 +15,12 @@ npm install react-native-youtube-popup-player
 ## Installing dependencies
 
 ```sh
-npm install react-native-vector-icons react-native-modal react-native-webview react-native-youtube-iframe-player
+npm install react-native-vector-icons react-native-modal react-native-webview react-native-youtube-iframe
 ```
 - [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons)
 - [react-native-modal](https://github.com/react-native-modal/react-native-modal)
 - [react-native-webview](https://github.com/react-native-webview/react-native-webview)
-- [react-native-youtube-iframe-player](https://github.com/limkimsan/react-native-youtube-iframe-player)
+- [react-native-youtube-iframe](https://github.com/LonelyCpp/react-native-youtube-iframe)
 
 #### Note:
 You need to make configuration on iOS and Android by following the instruction from the above dependencies libraries.
@@ -39,23 +40,24 @@ const [modalVisible, setModalVisible] = React.useState(false);
 <YoutubePopupPlayer
   videoUrl='https://www.youtube.com/watch?abcdefghi'
   modalVisible={modalVisible}
+  hasInternet={hasInternet}
+  playerPaddingTop='31%'
   messageLabelStyle={{fontSize: xLargeFontSize()}}
   closeModal={() => setModalVisible(false)}
 />
 ```
 ## Properties
 #### Basic
-| Prop                  |    Default    |       Type       |  Optional  | Description                                                                  |
-| :-------------------- | :-----------: | :--------------: | :--------: | :----------------------------------------------------------------------------|
-| videoUrl              |      null     |     `string`     |   `false`  | The use of the Youtube video                                                 |
-| modalVisible          |     false     |     `boolean`    |   `false`  | The status to open or close the video player popup modal                     |
-| locale                |     'km'      |     `string`     |   `true`   | The locale of the warning message (options: `km` or `en`)                    |
-| messageIconSize       |      50       |     `number`     |   `true`   | The size of the warning icon when there is no internet or no video url       |
-| iconColor             |   '#ffffff'   |     `string`     |   `true`   | The color of the icon of the warning message                                 |
-| isTablet              |     false     |     `boolean`    |   `true`   | The device is tablet or mobile                                               |
-| iframeHeight          |      210      |     `number`     |   `true`   | The height of the iframe                                                     |
-| loadingIndicatorColor |   '#ffffff'   |     `string`     |   `true`   | The color of the loading indicator                                           |
-| durationFontSize      |      11       |     `number`     |   `true`   | The font size of the duration and play seconds                               |
+| Prop               |    Default    |       Type       |  Optional  | Description                                                                  |
+| :----------------- | :-----------: | :--------------: | :--------: | :----------------------------------------------------------------------------|
+| videoUrl           |      null     |     `string`     |   `false`  | The use of the Youtube video                                                 |
+| modalVisible       |     false     |     `boolean`    |   `false`  | The status to open or close the video player popup modal                     |
+| hasInternet        |     false     |     `boolean`    |   `false`  | For checking the internet status before playing the video                    |
+| playerPaddingTop   |      null     |  `string/number` |   `true`   | The padding top of the video player                                          |
+| locale             |     'km'      |     `string`     |   `true`   | The locale of the warning message (options: `km` or `en`)                    |
+| messageIconSize    |      50       |     `number`     |   `true`   | The size of the warning icon when there is no internet or no video url       |
+| iconColor          |   '#ffffff'   |     `string`     |   `true`   | The color of the icon of the warning message                                 |
+| indicatorColor     |   '#ffffff'   |     `string`     |   `true`   | The color of the loading indicator                                           |
 
 - The default icon size of the warning icon will be `50dp` and `45dp` for the low pixel devices
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-youtube-popup-player",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A custom Youtube iframe player with a popup style and can exit the player by swiping down/up",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -84,7 +84,7 @@
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-vector-icons": ">=9.2.0",
     "react-native-webview": "^13.13.2",
-    "react-native-youtube-iframe-player": "*"
+    "react-native-youtube-iframe": "^2.2.2"
   },
   "engines": {
     "node": ">= 16.0.0"

--- a/src/components/YoutubePopupPlayerComponent.js
+++ b/src/components/YoutubePopupPlayerComponent.js
@@ -1,27 +1,22 @@
 import React, {useEffect, useState, useRef} from 'react';
-import {View} from 'react-native';
+import {View, ActivityIndicator} from 'react-native';
 import Modal from 'react-native-modal';
-import NetInfo from '@react-native-community/netinfo'
-import YoutubeIframePlayer from 'react-native-youtube-iframe-player';
+import YoutubePlayer from "react-native-youtube-iframe";
 
 import WarningMessageComponent from './WarningMessageComponent';
+import youtubeHelper from '../helpers/youtube_helper';
 
 const YoutubePopupPlayerComponent = (props) => {
   const [isLoading, setIsLoading] = useState(true);
-  const [hasInternet, setHasInternet] = React.useState(true)
   const [hasErrorNetwork, setHasErrorNetwork] = useState(false);
   const isLoadingRef = useRef(isLoading);
-  const hasInternetRef = useRef(true);
+  const hasInternetRef = useRef(props.hasInternet);
   useEffect(() => {
     let timeout = null
     if (props.modalVisible) {
-      NetInfo.fetch().then(state => {
-        if (hasInternet != state.isConnected)
-          setHasInternet(state.isConnected)
-      });
       setIsLoading(true);
       setHasErrorNetwork(false);
-      hasInternetRef.current = hasInternet
+      hasInternetRef.current = props.hasInternet
       isLoadingRef.current = true
       timeout = setTimeout(() => {
         setHasErrorNetwork(hasInternetRef.current && isLoadingRef.current);
@@ -42,23 +37,25 @@ const YoutubePopupPlayerComponent = (props) => {
   }
 
   const renderContent = () => {
-    if (!!props.videoUrl && hasInternet && !hasErrorNetwork)
+    if (!!props.videoUrl && props.hasInternet && !hasErrorNetwork)
       return (
         <View style={{height: '100%', width: "100%", justifyContent: 'center'}}>
-          <YoutubeIframePlayer
-            videoUrl={props.videoUrl}
-            height={props.iframeHeight}
-            width='100%'
-            locale={props.locale}
-            durationFontSize={props.durationFontSize}
-            loadingColor={props.loadingIndicatorColor || '#ffffff'}
-            isTablet={props.isTablet}
+          { (props.hasInternet && isLoading) &&
+            <ActivityIndicator size="large" color={props.indicatorColor || '#ffffff'} style={{position: 'absolute', alignSelf: 'center'}} />
+          }
+          <YoutubePlayer
+            height={'100%'}
+            play={true}
+            videoId={youtubeHelper.getVideoId(props.videoUrl)}
             onReady={() => onReady()}
+            webViewProps={{
+              containerStyle: {paddingTop: props.playerPaddingTop || '55%'}
+            }}
           />
         </View>
       )
 
-    return <WarningMessageComponent locale={props.locale} hasInternet={hasInternet} hasErrorNetwork={hasErrorNetwork} closeModal={() => props.closeModal()}
+    return <WarningMessageComponent locale={props.locale} hasInternet={props.hasInternet} hasErrorNetwork={hasErrorNetwork} closeModal={() => props.closeModal()}
               iconColor={props.iconColor} messageLabelStyle={props.messageLabelStyle} messageIconSize={props.messageIconSize} closeButtonStyle={props.closeButtonStyle}
            />
   }


### PR DESCRIPTION
This pull request reverts to using react-native-youtube-iframe because react-native-youtube-iframe-player has an error when sliding the player slider.